### PR TITLE
Fixes indentation for the codeql & node-ci templates

### DIFF
--- a/src/templates/github/codeql-analysis.template.ts
+++ b/src/templates/github/codeql-analysis.template.ts
@@ -21,62 +21,61 @@ export function codeqlAnalysis() {
 name: "CodeQL"
 
 on:
-push:
-branches: [ master ]
-pull_request:
-# The branches below must be a subset of the branches above
-branches: [ master ]
-schedule:
-- cron: '33 9 * * 3'
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '33 9 * * 3'
 
 jobs:
-analyze:
-name: Analyze
-runs-on: ubuntu-latest
-permissions:
-    actions: read
-    contents: read
-    security-events: write
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
-strategy:
-    fail-fast: false
-    matrix:
-    language: [ 'javascript' ]
-    # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-    # Learn more about CodeQL language support at https://git.io/codeql-language-support
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+        # CodeQL supports ['cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby']
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
-steps:
-- name: Checkout repository
-    uses: actions/checkout@v2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-# Initializes the CodeQL tools for scanning.
-- name: Initialize CodeQL
-    uses: github/codeql-action/init@v1
-    with:
-    languages: $ {{ matrix.language }}
-    # If you wish to specify custom queries, you can do so here or in a config file.
-    # By default, queries listed here will override any specified in a config file.
-    # Prefix the list here with "+" to use these queries and those in the config file.
-    # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: $ {{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-# Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-# If this step fails, then you should remove it and run the build manually (see below)
-- name: Autobuild
-    uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-# ℹ️ Command-line programs to run using the OS shell.
-# 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-# ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-#    and modify them (or add more) to build your code if your project
-#    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-#- run: |
-#   make bootstrap
-#   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-- name: Perform CodeQL Analysis
-    uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
         `;
     }
 

--- a/src/templates/github/node-ci.template.ts
+++ b/src/templates/github/node-ci.template.ts
@@ -7,35 +7,43 @@ export function nodeCI() {
     const filePath = GithubPath.WORKFLOWS;
 
     const fileContent = (): string => {
-        return `name: Node CI
+        return `
+        name: Node CI
 
-on: [push]
-
-jobs:
-    build:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-        matrix:
-        node-version: [10.x, 12.x]
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js $ {{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-        node-version: $ {{ matrix.node-version }}
-    - name: Run refresh
-        run: npm run refresh
-    - name: Run tscov
-        run: npm run tscov
-    - name: Run build
-        run: npm run build
-    - name: Run docs
-        run: npm run docs
-        env:
-        CI: true
+        on:
+          push:
+            branches:
+              - main
+        
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+        
+            strategy:
+              matrix:
+                node-version: [10.x, 12.x]
+        
+            steps:
+              - uses: actions/checkout@v2
+        
+              - name: Use Node.js $ {{ matrix.node-version }}
+                uses: actions/setup-node@v2
+                with:
+                  node-version: $ {{ matrix.node-version }}
+        
+              - name: Run refresh
+                run: npm run refresh
+        
+              - name: Run tscov
+                run: npm run tscov
+        
+              - name: Run build
+                run: npm run build
+        
+              - name: Run docs
+                run: npm run docs
+                env:
+                  CI: true
         `;
     }
 


### PR DESCRIPTION
When generating these two files, there is an indentation issue that has to be fixed in every project

<img width="742" alt="image" src="https://github.com/jeroenouw/cgx/assets/12240579/8e174d4b-354c-4c41-b161-50b1903d7822">

<img width="1026" alt="image" src="https://github.com/jeroenouw/cgx/assets/12240579/b757ce29-b52a-46d6-86d2-bbbe1fbeead8">

